### PR TITLE
Setup Tools Packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+from setuptools import setup, find_packages
+
+setup(
+    name='pyrowl',
+    version='0.1',
+    packages=find_packages()
+)
+


### PR DESCRIPTION
It would be nice if we could just easy_install pyrowl.  I've packaged it with a minimal setuptools configuration (not quite enough to submit it to PyPI, but enough to make a source package).
