### PR TITLE
Push to all keys at once with batch mode

### DIFF
--- a/pynma/pynma.py
+++ b/pynma/pynma.py
@@ -74,7 +74,7 @@ takes 5 arguments:
  - (opt) html:        shortcut for contenttype=text/html
 
 Warning: using batch_mode will return error only if all API keys are bad
- cf: http://nma.usk.bz/api.php
+ cf: https://www.notifymyandroid.com/api.jsp
 """
         datas = {
             'application': application[:256].encode('utf8'),


### PR DESCRIPTION
NMA (no longer?) imposes a limit on the number of API keys to push notification to with a single API call, so we can send all the API keys at once when using batch mode
