### PR TITLE
Added support for SNI, required by Prowl since August 2017

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pyrowl',
-    version='0.1',
+    version='0.11',
     packages=find_packages()
 )
 


### PR DESCRIPTION
Hi, here is a quick fix to put Pyrowl back in a working state following issue #8 

Just did basic testing : my iPhone 6s / iOS 11.2.6 with Prowl installed receives notification messages back again